### PR TITLE
fix: update all Docker actions for compatibility

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -51,7 +51,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
Update all Docker-related GitHub Actions to latest major versions to fix compatibility issues.

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v4 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v5 | v6 |

## Problem
PR #2 updated only `actions/checkout` and `docker/build-push-action` to v6, but left `docker/metadata-action` at v5. This caused invalid tag generation with error:
```
invalid tag "ghcr.io/mosher-labs/pihole6-exporter:-2188651": invalid reference format
```

## Solution
Update all Docker actions together to ensure compatibility.

## Test plan
- [ ] PR build should succeed
- [ ] Once merged, close PR #2 as superseded

🤖 Generated with [Claude Code](https://claude.com/claude-code)